### PR TITLE
Fix non-working useCheckNetwork on rinkeby

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Hyphal
+# Seker
 
 ## Setup
 

--- a/src/components/Modals/MetamaskWarnModal/index.tsx
+++ b/src/components/Modals/MetamaskWarnModal/index.tsx
@@ -14,6 +14,7 @@ const MetamaskWarnModal: FunctionComponent = () => {
 			title="Wrong / Missing Network"
 			width={750}
 			height={580}
+			zIndex={10}
 		>
 			<div className="metamask-warning">
 				<p>

--- a/src/hooks/useCheckNetwork.ts
+++ b/src/hooks/useCheckNetwork.ts
@@ -21,6 +21,7 @@ const useCheckNetwork = <T extends unknown[], R>(
 				method: "wallet_switchEthereumChain",
 				params: [
 					{
+						// TODO: revisit this part when we will be supporting more networks
 						chainId: isRinkeby ? "0x4" : BigNumber.from(requiredChainId).toHexString()
 					}
 				]

--- a/src/hooks/useCheckNetwork.ts
+++ b/src/hooks/useCheckNetwork.ts
@@ -15,12 +15,13 @@ const useCheckNetwork = <T extends unknown[], R>(
 		if (!externalProvider) {
 			throw new Error("No wallet connected")
 		}
+		const isRinkeby = requiredChainId === 4
 		try {
 			await externalProvider.request!({
 				method: "wallet_switchEthereumChain",
 				params: [
 					{
-						chainId: BigNumber.from(requiredChainId).toHexString()
+						chainId: isRinkeby ? "0x4" : BigNumber.from(requiredChainId).toHexString()
 					}
 				]
 			})


### PR DESCRIPTION
- Hardcode `chainID` for `rinkeby` network in `useCheckNetwork`
- Bump `zIndex` for `MetamaskWarnModal`
- Change Hyphal heading in README to Seker

This hardcoding is caused by weird Metamask behavior when hex for number < 16, thus generated with extra leading zero. Most likely we will need a more generic solution, but need to properly test on other networks.
P.S. To verify odd behavior - you could test DAO creation on https://rinkeby.sekerdao.com